### PR TITLE
#19: Use localStorage to store tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   lint:
+    name: Lint (ESLint)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - run: npm ci
       - run: npm run test
 
@@ -32,6 +32,6 @@ jobs:
         uses: cypress-io/github-action@v7
         with:
           start: npm run dev
-          wait-on: 'http://localhost:5173'
+          wait-on: "http://localhost:5173"
           wait-on-timeout: 60
           browser: chrome

--- a/src/context/TodoProvider.tsx
+++ b/src/context/TodoProvider.tsx
@@ -1,12 +1,39 @@
-import { useReducer } from "react";
+import { useReducer, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 
 import type { TodoItemType } from "../components/TodosList";
 import { TodoContext, initialState } from "./TodoContext";
 import TodoReducer from "./TodoReducer";
 
+const STORAGE_KEY = "todos";
+
 export const TodoProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(TodoReducer, initialState);
+  const hasMounted = useRef(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored !== null) {
+        const parsed = JSON.parse(stored) as TodoItemType[];
+        dispatch({ type: "LOAD_TODOS", payload: parsed });
+      }
+    } catch (err) {
+      console.warn("Failed to load todos from localStorage:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.todoItems));
+    } catch (err) {
+      console.warn("Failed to save todos to localStorage:", err);
+    }
+  }, [state.todoItems]);
 
   // Actions
 

--- a/src/context/TodoReducer.ts
+++ b/src/context/TodoReducer.ts
@@ -26,12 +26,18 @@ type SetEditingIdAction = {
   payload: string | null;
 };
 
+type LoadTodosAction = {
+  type: "LOAD_TODOS";
+  payload: TodoItemType[];
+};
+
 type Action =
   | AddTodoAction
   | ToggleTodoCompleteAction
   | DeleteTodoAction
   | UpdateTodoAction
-  | SetEditingIdAction;
+  | SetEditingIdAction
+  | LoadTodosAction;
 
 export default (state: TodoListState, action: Action): TodoListState => {
   switch (action.type) {
@@ -69,6 +75,11 @@ export default (state: TodoListState, action: Action): TodoListState => {
       return {
         ...state,
         editingId: action.payload,
+      };
+    case "LOAD_TODOS":
+      return {
+        ...state,
+        todoItems: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
Store tasks in localStorage to persist them across page visits.
Update the TodoProvider to load tasks from localStorage on initialization and save them whenever they change. This will allow users to keep their task list even after closing or refreshing the page.

Closes #19.