### PR TITLE
#7: Add form validation and display errors

### DIFF
--- a/cypress/e2e/AddTodo.cy.ts
+++ b/cypress/e2e/AddTodo.cy.ts
@@ -75,7 +75,7 @@ describe("add todo item form", () => {
   it("should show an inline error when the task exceeds 500 characters", () => {
     const longTask = "a".repeat(501);
 
-    cy.getByTestId("task-input-field").invoke("val", longTask).trigger("input");
+    cy.getByTestId("task-input-field").type(longTask, { timeout: 15000 });
     cy.getByTestId("task-submit-btn").click();
 
     cy.get("[role='alert']").should(
@@ -98,6 +98,8 @@ describe("add todo item form", () => {
     cy.getByTestId("task-input-field").type("   ");
     cy.getByTestId("task-submit-btn").click();
 
-    cy.getByTestId("todos-list").find("li").should("not.exist");
+    cy.getByTestId("todos-list", {
+      timeout: 0,
+    }).should("not.exist");
   });
 });

--- a/cypress/e2e/AddTodo.cy.ts
+++ b/cypress/e2e/AddTodo.cy.ts
@@ -43,4 +43,61 @@ describe("add todo item form", () => {
       .should("be.visible")
       .and("have.text", task);
   });
+
+  it("should show an inline error when submitted with an empty input", () => {
+    cy.getByTestId("task-submit-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Please add a task description.",
+    );
+  });
+
+  it("should show an inline error when submitted with only whitespace", () => {
+    cy.getByTestId("task-input-field").type("   ");
+    cy.getByTestId("task-submit-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Please add a task description.",
+    );
+  });
+
+  it("should clear the inline error when the user starts typing", () => {
+    cy.getByTestId("task-submit-btn").click();
+    cy.get("[role='alert']").should("exist");
+
+    cy.getByTestId("task-input-field").type("S");
+
+    cy.get("[role='alert']").should("not.exist");
+  });
+
+  it("should show an inline error when the task exceeds 500 characters", () => {
+    const longTask = "a".repeat(501);
+
+    cy.getByTestId("task-input-field").invoke("val", longTask).trigger("input");
+    cy.getByTestId("task-submit-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Task must be 500 characters or fewer.",
+    );
+  });
+
+  it("should display the character counter at all times", () => {
+    // Assert counter is visible on empty input
+    cy.contains("0/500").should("be.visible");
+
+    cy.getByTestId("task-input-field").type("Hello");
+
+    // Assert counter updates as the user types
+    cy.contains("5/500").should("be.visible");
+  });
+
+  it("should not add a whitespace-only task to the list", () => {
+    cy.getByTestId("task-input-field").type("   ");
+    cy.getByTestId("task-submit-btn").click();
+
+    cy.getByTestId("todos-list").find("li").should("not.exist");
+  });
 });

--- a/cypress/e2e/TodoItem.cy.ts
+++ b/cypress/e2e/TodoItem.cy.ts
@@ -36,6 +36,7 @@ describe("todo list", () => {
     cy.contains("li", originalTask).findByTestId("edit-task-btn").click();
 
     // The input should be visible and focused
+    // Showing a different way to use .filter() here
     cy.getByTestId("todo-item")
       .find("input[type='text']")
       .filter((_, el) => (el as HTMLInputElement).value === originalTask)
@@ -134,20 +135,25 @@ describe("todo list", () => {
   });
 
   it("should show an inline error in edit mode when the task exceeds 500 characters", () => {
-    cy.addTask(faker.word.words());
-    cy.getByTestId("todos-list")
-      .find("li")
-      .first()
-      .findByTestId("edit-task-btn")
-      .click();
+    const originalTask = faker.word.words();
+    const longTask = "a".repeat(501);
+
+    cy.addTask(originalTask);
+
+    cy.contains("li", originalTask).findByTestId("edit-task-btn").click();
 
     // Set a value exceeding the character limit and attempt to save
-    const longTask = "a".repeat(501);
     cy.getByTestId("todo-item")
       .find("input[type='text']")
-      .invoke("val", longTask)
-      .trigger("input");
-    cy.getByTestId("save-task-btn").click();
+      .filter(`[value="${originalTask}"]`)
+      .clear()
+      .type(longTask, { timeout: 15000 });
+
+    cy.getByTestId("todo-item")
+      .find("input[type='text']")
+      .filter(`[value="${longTask}"]`)
+      .getByTestId("save-task-btn")
+      .click();
 
     cy.get("[role='alert']").should(
       "have.text",

--- a/cypress/e2e/TodoItem.cy.ts
+++ b/cypress/e2e/TodoItem.cy.ts
@@ -67,7 +67,6 @@ describe("todo list", () => {
     cy.addTask(task);
     cy.addTask(faker.word.words());
 
-    // All of the below can use closures, but at the cost of readability
     cy.getByTestId("todos-list").contains(task).should("exist");
 
     // Delete the task
@@ -79,5 +78,98 @@ describe("todo list", () => {
     })
       .contains(task)
       .should("not.exist");
+  });
+
+  it("should show an inline error in edit mode when saved with an empty input", () => {
+    cy.addTask(faker.word.words());
+    cy.getByTestId("todos-list")
+      .find("li")
+      .first()
+      .findByTestId("edit-task-btn")
+      .click();
+
+    // Clear the input and attempt to save
+    cy.getByTestId("todo-item").find("input[type='text']").clear();
+    cy.getByTestId("save-task-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Please add a task description.",
+    );
+  });
+
+  it("should show an inline error in edit mode when saved with only whitespace", () => {
+    cy.addTask(faker.word.words());
+    cy.getByTestId("todos-list")
+      .find("li")
+      .first()
+      .findByTestId("edit-task-btn")
+      .click();
+
+    // Replace with whitespace and attempt to save
+    cy.getByTestId("todo-item").find("input[type='text']").clear().type("   ");
+    cy.getByTestId("save-task-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Please add a task description.",
+    );
+  });
+
+  it("should clear the inline error in edit mode when the user starts typing", () => {
+    cy.addTask(faker.word.words());
+    cy.getByTestId("todos-list")
+      .find("li")
+      .first()
+      .findByTestId("edit-task-btn")
+      .click();
+    cy.getByTestId("todo-item").find("input[type='text']").clear();
+    cy.getByTestId("save-task-btn").click();
+    cy.get("[role='alert']").should("exist");
+
+    // Type a character to clear the error
+    cy.getByTestId("todo-item").find("input[type='text']").type("S");
+
+    cy.get("[role='alert']").should("not.exist");
+  });
+
+  it("should show an inline error in edit mode when the task exceeds 500 characters", () => {
+    cy.addTask(faker.word.words());
+    cy.getByTestId("todos-list")
+      .find("li")
+      .first()
+      .findByTestId("edit-task-btn")
+      .click();
+
+    // Set a value exceeding the character limit and attempt to save
+    const longTask = "a".repeat(501);
+    cy.getByTestId("todo-item")
+      .find("input[type='text']")
+      .invoke("val", longTask)
+      .trigger("input");
+    cy.getByTestId("save-task-btn").click();
+
+    cy.get("[role='alert']").should(
+      "have.text",
+      "Task must be 500 characters or fewer.",
+    );
+  });
+
+  it("should not save an empty task in edit mode", () => {
+    const originalTask = faker.word.words();
+    cy.addTask(originalTask);
+    cy.getByTestId("todos-list")
+      .find("li")
+      .first()
+      .findByTestId("edit-task-btn")
+      .click();
+
+    // Clear the input and attempt to save
+    cy.getByTestId("todo-item").find("input[type='text']").clear();
+    cy.getByTestId("save-task-btn").click();
+
+    // Assert that original task text is preserved after cancel
+    cy.getByTestId("cancel-task-btn").click();
+    cy.getByTestId("todos-list").contains(originalTask).should("exist");
   });
 });

--- a/cypress/e2e/TodoItem.cy.ts
+++ b/cypress/e2e/TodoItem.cy.ts
@@ -134,6 +134,28 @@ describe("todo list", () => {
     cy.get("[role='alert']").should("not.exist");
   });
 
+  it("should show the character counter in edit mode when near the character limit", () => {
+    const originalTask = "Hello";
+    const nearLimitTask = "a".repeat(450);
+
+    cy.addTask(originalTask);
+
+    cy.contains("li", originalTask).findByTestId("edit-task-btn").click();
+
+    // The character counter should not be visible yet
+    cy.contains("5/500", { timeout: 0 }).should("not.exist");
+
+    // Clear and type a value at the warn threshold (450 characters)
+    cy.getByTestId("todo-item")
+      .find("input[type='text']")
+      .filter(`[value="${originalTask}"]`)
+      .clear()
+      .type(nearLimitTask, { timeout: 15000 });
+
+    // Assert that the character counter is visible with the correct count
+    cy.contains("450/500").should("be.visible");
+  });
+
   it("should show an inline error in edit mode when the task exceeds 500 characters", () => {
     const originalTask = faker.word.words();
     const longTask = "a".repeat(501);

--- a/src/components/AddTodo.test.tsx
+++ b/src/components/AddTodo.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { vi } from "vitest";
 
 import AddTodo from "./AddTodo";
 
@@ -19,16 +18,39 @@ describe("AddTodo", () => {
     expect(input).toHaveValue("SampleTodoTask");
   });
 
-  test("should show an alert when form is submitted with empty input", () => {
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-
+  test("should show an inline error when form is submitted with empty input", () => {
     render(<AddTodo />);
     const form = screen.getByTestId("task-form");
 
     fireEvent.submit(form);
 
-    expect(alertSpy).toHaveBeenCalledWith("Please add a task description.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Please add a task description.",
+    );
+  });
 
-    alertSpy.mockRestore();
+  test("should clear the inline error when user starts typing", () => {
+    render(<AddTodo />);
+    const form = screen.getByTestId("task-form");
+    const input = screen.getByTestId(inputTestId);
+
+    fireEvent.submit(form);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "S" } });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  test("should show an inline error when task exceeds the character limit", () => {
+    render(<AddTodo />);
+    const input = screen.getByTestId(inputTestId);
+    const form = screen.getByTestId("task-form");
+
+    fireEvent.change(input, { target: { value: "a".repeat(501) } });
+    fireEvent.submit(form);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Task must be 500 characters or fewer.",
+    );
   });
 });

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import { FaRegPlusSquare } from "react-icons/fa";
 import { v4 as uuidv4 } from "uuid";
 
@@ -6,6 +6,8 @@ import { TodoContext } from "../context/TodoContext";
 
 export default function AddTodo() {
   const [title, setTitle] = useState("");
+  const [error, setError] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const { addTodo } = useContext(TodoContext);
 
@@ -14,22 +16,24 @@ export default function AddTodo() {
     evt.preventDefault();
 
     // Validate todo text
-    if (!title) {
-      // TODO Replace with toast
-      alert("Please add a task description.");
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setError("Please add a task description.");
+      inputRef.current?.focus();
       return;
     }
 
     const newTodo = {
       id: uuidv4(),
-      title,
+      title: trimmedTitle,
       completed: false,
     };
 
     addTodo(newTodo);
 
-    // Clear task text in component state
+    // Clear task text and any previous error in component state
     setTitle("");
+    setError("");
   };
 
   return (
@@ -40,11 +44,15 @@ export default function AddTodo() {
         data-testid="task-form"
       >
         <input
+          ref={inputRef}
           name="task-title"
           type="text"
           placeholder="Add task..."
           value={title}
-          onChange={(evt) => setTitle(evt.target.value)}
+          onChange={(evt) => {
+            setTitle(evt.target.value);
+            if (error) setError("");
+          }}
           className="flex-1 px-2.5 text-base md:text-lg bg-gray-200 placeholder-gray-500 focus:outline-none"
           data-testid="task-input-field"
         />
@@ -56,6 +64,11 @@ export default function AddTodo() {
           <FaRegPlusSquare />
         </button>
       </form>
+      {error && (
+        <p className="text-red-500 text-sm mt-1" role="alert">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from "uuid";
 
 import { TodoContext } from "../context/TodoContext";
 
+const TASK_TITLE_MAX_LENGTH = 500;
+
 export default function AddTodo() {
   const [title, setTitle] = useState("");
   const [error, setError] = useState("");
@@ -19,6 +21,12 @@ export default function AddTodo() {
     const trimmedTitle = title.trim();
     if (!trimmedTitle) {
       setError("Please add a task description.");
+      inputRef.current?.focus();
+      return;
+    }
+
+    if (title.length > TASK_TITLE_MAX_LENGTH) {
+      setError(`Task must be ${TASK_TITLE_MAX_LENGTH} characters or fewer.`);
       inputRef.current?.focus();
       return;
     }
@@ -50,8 +58,15 @@ export default function AddTodo() {
           placeholder="Add task..."
           value={title}
           onChange={(evt) => {
-            setTitle(evt.target.value);
-            if (error) setError("");
+            const newValue = evt.target.value;
+            setTitle(newValue);
+            if (newValue.length > TASK_TITLE_MAX_LENGTH) {
+              setError(
+                `Task must be ${TASK_TITLE_MAX_LENGTH} characters or fewer.`,
+              );
+            } else if (error) {
+              setError("");
+            }
           }}
           className="flex-1 px-2.5 text-base md:text-lg bg-gray-200 placeholder-gray-500 focus:outline-none"
           data-testid="task-input-field"
@@ -64,11 +79,25 @@ export default function AddTodo() {
           <FaRegPlusSquare />
         </button>
       </form>
-      {error && (
-        <p className="text-red-500 text-sm mt-1" role="alert">
-          {error}
-        </p>
-      )}
+      <div className="flex items-start justify-between mt-1">
+        {error ? (
+          <p className="text-red-500 text-sm" role="alert">
+            {error}
+          </p>
+        ) : (
+          <span />
+        )}
+        <span
+          className={`text-sm ml-2 shrink-0 ${
+            title.length > TASK_TITLE_MAX_LENGTH
+              ? "text-red-500"
+              : "text-gray-400"
+          }`}
+          aria-live="polite"
+        >
+          {title.length}/{TASK_TITLE_MAX_LENGTH}
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -10,6 +10,7 @@ interface TodoItemProps {
 
 export default function TodoItem({ todo }: TodoItemProps) {
   const [editValue, setEditValue] = useState(todo.title);
+  const [editError, setEditError] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const {
     toggleTodoComplete,
@@ -36,16 +37,19 @@ export default function TodoItem({ todo }: TodoItemProps) {
   const handleSave = () => {
     const trimmedValue = editValue.trim();
     if (!trimmedValue) {
-      // Prevent empty save, keep focus on input
+      setEditError("Please add a task description.");
+      inputRef.current?.focus();
       return;
     }
     updateTodo(todo.id, trimmedValue);
     setEditingId(null);
+    setEditError("");
   };
 
   const handleCancel = () => {
     setEditingId(null);
     setEditValue(todo.title);
+    setEditError("");
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -79,15 +83,25 @@ export default function TodoItem({ todo }: TodoItemProps) {
         disabled={isEditing}
       />
       {isEditing ? (
-        <input
-          ref={inputRef}
-          type="text"
-          value={editValue}
-          onChange={(e) => setEditValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          className="flex-1 px-2 py-1 min-w-0 text-base md:text-lg bg-gray-100 border-b-2 border-pink-600 rounded-t focus:outline-none focus:bg-white transition duration-200 ease-in-out"
-          aria-label="Edit todo title"
-        />
+        <div className="flex-1 min-w-0">
+          <input
+            ref={inputRef}
+            type="text"
+            value={editValue}
+            onChange={(e) => {
+              setEditValue(e.target.value);
+              if (editError) setEditError("");
+            }}
+            onKeyDown={handleKeyDown}
+            className="w-full px-2 py-1 text-base md:text-lg bg-gray-100 border-b-2 border-pink-600 rounded-t focus:outline-none focus:bg-white transition duration-200 ease-in-out"
+            aria-label="Edit todo title"
+          />
+          {editError && (
+            <p className="text-red-500 text-sm mt-1" role="alert">
+              {editError}
+            </p>
+          )}
+        </div>
       ) : (
         <span className="flex-1 px-2 min-w-0 break-words">{todo.title}</span>
       )}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -4,6 +4,9 @@ import { FaEdit, FaSave, FaTimes, FaTrashAlt } from "react-icons/fa";
 import { TodoContext } from "../context/TodoContext";
 import type { TodoItemType } from "./TodosList";
 
+const TASK_TITLE_MAX_LENGTH = 500;
+const TASK_TITLE_WARN_THRESHOLD = 450;
+
 interface TodoItemProps {
   todo: TodoItemType;
 }
@@ -41,6 +44,15 @@ export default function TodoItem({ todo }: TodoItemProps) {
       inputRef.current?.focus();
       return;
     }
+
+    if (editValue.length > TASK_TITLE_MAX_LENGTH) {
+      setEditError(
+        `Task must be ${TASK_TITLE_MAX_LENGTH} characters or fewer.`,
+      );
+      inputRef.current?.focus();
+      return;
+    }
+
     updateTodo(todo.id, trimmedValue);
     setEditingId(null);
     setEditError("");
@@ -89,17 +101,42 @@ export default function TodoItem({ todo }: TodoItemProps) {
             type="text"
             value={editValue}
             onChange={(e) => {
-              setEditValue(e.target.value);
-              if (editError) setEditError("");
+              const newValue = e.target.value;
+              setEditValue(newValue);
+              if (newValue.length > TASK_TITLE_MAX_LENGTH) {
+                setEditError(
+                  `Task must be ${TASK_TITLE_MAX_LENGTH} characters or fewer.`,
+                );
+              } else if (editError) {
+                setEditError("");
+              }
             }}
             onKeyDown={handleKeyDown}
             className="w-full px-2 py-1 text-base md:text-lg bg-gray-100 border-b-2 border-pink-600 rounded-t focus:outline-none focus:bg-white transition duration-200 ease-in-out"
             aria-label="Edit todo title"
           />
-          {editError && (
-            <p className="text-red-500 text-sm mt-1" role="alert">
-              {editError}
-            </p>
+          {(editError || editValue.length >= TASK_TITLE_WARN_THRESHOLD) && (
+            <div className="flex items-start justify-between mt-1">
+              {editError ? (
+                <p className="text-red-500 text-sm" role="alert">
+                  {editError}
+                </p>
+              ) : (
+                <span />
+              )}
+              {editValue.length >= TASK_TITLE_WARN_THRESHOLD && (
+                <span
+                  className={`text-sm ml-2 shrink-0 ${
+                    editValue.length > TASK_TITLE_MAX_LENGTH
+                      ? "text-red-500"
+                      : "text-gray-400"
+                  }`}
+                  aria-live="polite"
+                >
+                  {editValue.length}/{TASK_TITLE_MAX_LENGTH}
+                </span>
+              )}
+            </div>
           )}
         </div>
       ) : (


### PR DESCRIPTION
Replace use of `alert()` with actual error that appear below the input field.
Add validation and error handling in edit mode.
Add a character limit and implement it in both in Add and Edit modes.
The character limit will always be visible near the input field for adding a task. In edit mode, the character limit will appear only when a task is near the limit (at >=450 characters).

Closes #7.